### PR TITLE
Fix chart release process

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -9,9 +9,28 @@ jobs:
   build:
     name: Build
     runs-on: ubuntu-latest
+    defaults:
+      run:
+        shell: bash
     steps:
       - name: Check out code into the Go module directory
         uses: actions/checkout@v1
+
+      - name: Parse Parameters
+        id: params
+        run: |
+          GIT_TAG=${GITHUB_REF#'refs/tags/'}
+          echo ::set-output name=git_tag::$GIT_TAG
+          while IFS=$': \t' read -r marker v; do
+            case $marker in
+              Release)
+                echo ::set-output name=release::$v
+                ;;
+              Release-tracker)
+                echo ::set-output name=release_tracker::$v
+                ;;
+            esac
+          done < <(git tag -l --format='%(body)' $GIT_TAG)
 
       - name: Install GitHub CLI
         run: |
@@ -33,25 +52,37 @@ jobs:
           echo "install helm 3"
           curl https://raw.githubusercontent.com/helm/helm/master/scripts/get-helm-3 | bash
           echo "package charts"
-          for chart in grafana-operator
-          do
-            helm package charts/${chart}
-            mkdir -p $HOME/charts/stable/${chart}
-            mv ${chart}-*.tgz $HOME/charts/stable/${chart}
-          done
+          find charts -maxdepth 1 -mindepth 1 -type d -exec helm package {} -d {} \;
+          helm repo index --merge $HOME/charts/stable/index.yaml --url https://charts.appscode.com/stable/ charts
+          mv charts/index.yaml $HOME/charts/stable/index.yaml
+          cd charts
+          find . -maxdepth 1 -mindepth 1 -type d -exec mkdir -p $HOME/charts/stable/{} \;
+          find . -path ./charts -prune -o -name '*.tgz' -exec mv {} $HOME/charts/stable/{} \;
 
       - name: Create pull request
         env:
           GITHUB_TOKEN: ${{ secrets.LGTM_GITHUB_TOKEN }}
         run: |
-          export PR_BRANCH=${GITHUB_REPOSITORY}/${GITHUB_RUN_ID}
-          echo $PR_BRANCH
+          pr_branch=${GITHUB_REPOSITORY}/${GITHUB_RUN_ID}
           cd $HOME/charts
-          git checkout -b $PR_BRANCH
+          git checkout -b $pr_branch
           git add --all
-          git commit -a -s -m "Push Searchlight charts for $GITHUB_REF"
-          git push origin $PR_BRANCH -f
+          ct_cmd="git commit -a -s -m \"Publish $GITHUB_REPOSITORY@${{ steps.params.outputs.git_tag }} charts\""
+          pr_cmd=$(cat <<EOF
           hub pull-request \
               --labels automerge \
-              --message "Push Searchlight charts for $GITHUB_REF" \
-              --message "Signed-off-by: $(git config --get user.name) <$(git config --get user.email)>" || true
+              --message "Publish $GITHUB_REPOSITORY@${{ steps.params.outputs.git_tag }} charts"
+          EOF
+          )
+          if [ ! -z  ${{ steps.params.outputs.release }} ]; then
+            ct_cmd="$ct_cmd --message \"Release: ${{ steps.params.outputs.release }}\""
+            pr_cmd="$pr_cmd --message \"Release: ${{ steps.params.outputs.release }}\""
+          fi
+          if [ ! -z  ${{ steps.params.outputs.release_tracker }} ]; then
+            ct_cmd="$ct_cmd --message \"Release-tracker: ${{ steps.params.outputs.release_tracker }}\""
+            pr_cmd="$pr_cmd --message \"Release-tracker: ${{ steps.params.outputs.release_tracker }}\""
+          fi
+          pr_cmd="$pr_cmd --message \"Signed-off-by: $(git config --get user.name) <$(git config --get user.email)>\""
+          eval "$ct_cmd"
+          git push -u origin HEAD -f
+          eval "$pr_cmd"


### PR DESCRIPTION
- Always use bash shell in release workflow
- Only update timestamp for new charts
- Update chart repo index.yaml in pr
- Make commit and pr subject repo agnostic
- Add autorelease label if Release-tracker: is present commit body

Signed-off-by: Tamal Saha <tamal@appscode.com>